### PR TITLE
Remove "return" statement in CPS code

### DIFF
--- a/chapters/03-enumeration.md
+++ b/chapters/03-enumeration.md
@@ -178,7 +178,7 @@ var binomial = function(){
 
 // CPS version:
 var cpsSample = function(k, dist){
-  return k(sample(dist))
+  k(sample(dist))
 }
 
 var cpsBinomial = function(k){


### PR DESCRIPTION
Note: Continuation Passing Style does not require "return" statements, so the inclusion of a return statement in one of the examples could be confusing.